### PR TITLE
Website refresh: homepage, recruiting status + 2 news posts

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -19,30 +19,24 @@ toc: false
 
 ## Opportunities
 
-::: {.callout-note}
-### We are currently recruiting!
+::: {.callout-tip}
+### Get in touch
 
-If you are interested in joining the lab as a Data Scientist, please get in touch.<br />
-<!-- You can find more information about this recruitment cycle at [this blog post](./posts/recruitment2023) (or under News). -->
+We do not have allocated funding for new positions at the moment, but we are always happy to hear from people interested in our work. If you would like to collaborate or find out more, please [get in touch](mailto:s.harris@ucl.ac.uk).
 :::
 
 ### Students
 
 Undergraduate students work as **research assistants**, learning about the scientific method and assisting in the collection and processing of research data. Research assistants attend weekly lab meetings and can expect a **letter of recommendation** describing their work in and contributions to the lab (please give one month of advanced notice). Opportunities to earn **co-authorship** on research products (e.g., conference presentations) are also occasionally offered to advanced research assistants.
 
-
-
-
 <!-- ## Email Us
-
 hello@uclhal.org
- -->
+-->
 ## Visit Us
 
 The UCL Health Algorithm Laboratory is based at **Institute of Health Informatics** at University College London.
 
 > **Street Address:** 222 Euston Road, London, NW1 2DA
-
 ```{=html}
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2482.3081696623235!2d-0.137801584241075!3d51.52590731717089!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x48761b260446fa31%3A0xc97a5981bb924a0d!2sUCL%20Institute%20Of%20Health%20Informatics!5e0!3m2!1sen!2suk!4v1668376825965!5m2!1sen!2suk" width="50%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 ```

--- a/index.qmd
+++ b/index.qmd
@@ -22,7 +22,7 @@ toc: false
 ::: {.callout-tip}
 ### Get in touch
 
-We do not have allocated funding for new positions at the moment, but we are always happy to hear from people interested in our work. If you would like to collaborate or find out more, please [get in touch](mailto:s.harris@ucl.ac.uk).
+We do not have allocated funding for new positions at the moment, but we are always happy to hear from people interested in our work. If you would like to collaborate or find out more, please [get in touch](mailto:steve.harris@ucl.ac.uk).
 :::
 
 ### Students

--- a/news/radix-sde-2025/index.qmd
+++ b/news/radix-sde-2025/index.qmd
@@ -1,0 +1,23 @@
+---
+title: "RADIX: Real-time Antimicrobial Digital Intervention Exchange"
+description: "RADIX was selected in late 2025 as one of four NHS-led Driver Projects for the new London Secure Data Environment, co-led by Dr Steve Harris and a multidisciplinary team of researchers."
+author: "Sharifah Omar"
+date: "2026-06-24"
+draft: false
+categories:
+  - news
+  - radix
+  - onelondon
+  - sde
+  - antimicrobial
+---
+
+RADIX (Real-time Antimicrobial Digital Intervention Exchange) was selected in late 2025 as one of four NHS-led Driver Projects for the new London Secure Data Environment (SDE), co-led by Dr Steve Harris (UCL, Institute of Health Informatics) alongside Professor Laura Shallcross, Dr Emily Baldwin, Professor Gwen Knight, Dr Akish Luintel, and Dr Sarah Keating.
+
+Dr Steve Harris leads the UCL Health Algorithms Laboratory, whose work on clinical data infrastructure and bedside AI deployment underpins the RADIX programme. The project draws directly on the lab's experience building EMAP and FlowEHR at UCLH, and on SAFEHR, the secure analytics environment that the lab uses to turn routine NHS data into research-ready assets.
+
+Antimicrobial resistance (AMR) is one of the defining public health challenges of our time. A major contributor is the fragmentation of patient records across care settings, making targeted prescribing difficult and leaving vulnerable patients, including those living with cancer or in care homes, at heightened risk of bug-drug mismatches.
+
+RADIX will use the OneLondon SDE to link antimicrobial prescribing and microbiology testing data across primary and acute care, and develop machine learning tools including point-of-care bug-drug mismatch prediction and a patient-level stewardship dashboard, with a focus on people living with cancer and those in care homes.
+
+RADIX is part of a wider OneLondon effort to demonstrate how London-wide linked data can deliver direct health improvement for Londoners ahead of the SDE's full launch in 2026.

--- a/news/ucl-festival-digital-2025/index.qmd
+++ b/news/ucl-festival-digital-2025/index.qmd
@@ -1,0 +1,20 @@
+---
+title: "HAL at the UCL Festival of Digital Research, Innovation and Scholarship"
+description: "Dr Steve Harris presented a keynote on SAFEHR at UCL's Festival of Digital Research on July 15 2025, demonstrating how NHS-embedded infrastructure is enabling real-world clinical AI deployment at UCLH."
+author: "Sharifah Omar"
+date: "2026-06-24"
+draft: false
+categories:
+  - news
+  - safehr
+  - emap
+  - conference
+---
+
+Dr Steve Harris, who leads the UCL Health Algorithms Laboratory, presented at UCL's Festival of Digital Research, Innovation and Scholarship on July 15 2025, delivering a keynote on SAFEHR (Secure and Anonymised Framework for Electronic Health Records), a NIHR UCLH BRC-funded collaboration between UCLH and UCL's Advanced Research Computing Centre.
+
+The talk described how SAFEHR transforms researcher access to multimodal healthcare data through three integrated pipelines: OMOP-ES for structured EHR data, PIXL for anonymising medical imaging including MRI, CT, and X-rays, and CogStack for processing unstructured clinical text.
+
+The infrastructure has already supported several high-impact research projects, including analysis of over 70,000 chest X-rays paired with EHR data to train models for detecting misplaced nasogastric tubes, research using 14,000 prostate MRIs with clinical outcomes, and studies leveraging 50,000 MRIs to inform personalised treatment for multiple sclerosis.
+
+The Festival brings together UCL's digital research community across computing, health informatics, and data science. The HAL team's participation reflects a broader effort to connect NHS-embedded infrastructure with the wider academic community and demonstrate that real-world clinical AI deployment is both possible and already underway at UCLH.


### PR DESCRIPTION
Website refresh — first batch of updates for Steve's review.

**Changes in this PR:**

1. `index.qmd` — Homepage Opportunities section updated:
2.    - Removed 'We are currently recruiting!' callout (no allocated funding currently)
3.    - Replaced with softer 'Get in touch' message linking to s.harris@ucl.ac.uk
4.    - Changed callout style from callout-note to callout-tip
2. `news/radix-sde-2025/index.qmd` — New news post: RADIX selected as NHS London SDE Driver Project
3. `news/ucl-festival-digital-2025/index.qmd` — New news post: HAL at UCL Festival of Digital Research
Please review and merge if happy, or leave comments with any changes needed.